### PR TITLE
[add] observer patternに機能追加

### DIFF
--- a/design_patterns/observer/observer.go
+++ b/design_patterns/observer/observer.go
@@ -18,6 +18,10 @@ type Item struct {
 	inStock      bool
 }
 
+type SystemLogger struct {
+	LogData []string
+}
+
 func NewItem(name string) *Item {
 	return &Item{
 		name: name,
@@ -50,9 +54,15 @@ type Customer struct {
 }
 
 func (c *Customer) Update(itemName string) {
-	msg := fmt.Sprintf("お客様 %s: %s が入荷しましたよ!", c.id, itemName)
+	msg := fmt.Sprintf("お客様 %s: %s が入荷しましたよ!\n", c.id, itemName)
 	c.ReceivedMsgs = append(c.ReceivedMsgs, msg)
 	fmt.Println(msg)
+}
+
+func (l *SystemLogger) Update(itemName string) {
+	logMsg := fmt.Sprintf("[Log] システム記録: アイテム「%s」の入荷イベントを検知しました。\n", itemName)
+	l.LogData = append(l.LogData, logMsg)
+	fmt.Println(logMsg)
 }
 
 func main() {
@@ -61,8 +71,12 @@ func main() {
 	customer1 := &Customer{id: "Alice"}
 	customer2 := &Customer{id: "Bob"}
 
+	logger := &SystemLogger{}
+
 	nintendoSwitch.Register(customer1)
 	nintendoSwitch.Register(customer2)
+
+	nintendoSwitch.Register(logger)
 
 	nintendoSwitch.UpdateAvailability()
 }

--- a/design_patterns/observer/observer_test.go
+++ b/design_patterns/observer/observer_test.go
@@ -10,8 +10,11 @@ func TestObserverNortification(t *testing.T) {
 	customer1 := &Customer{id: "TestUser1"}
 	customer2 := &Customer{id: "TestUser2"}
 
+	logger := &SystemLogger{}
+
 	item.Register(customer1)
 	item.Register(customer2)
+	item.Register(logger)
 
 	// 実行
 	item.UpdateAvailability()
@@ -20,12 +23,16 @@ func TestObserverNortification(t *testing.T) {
 	if len(customer1.ReceivedMsgs) != 1 {
 		t.Errorf("customer1 should have exactly 1 message, got %d", len(customer1.ReceivedMsgs))
 	}
-	expectedMsg1 := "お客様 TestUser1: PlayStation 5 が入荷しましたよ!"
+	expectedMsg1 := "お客様 TestUser1: PlayStation 5 が入荷しましたよ!\n"
 	if customer1.ReceivedMsgs[0] != expectedMsg1 {
 		t.Errorf("got %q, want %q", customer1.ReceivedMsgs[0], expectedMsg1)
 	}
 
 	if len(customer2.ReceivedMsgs) != 1 {
 		t.Errorf("customer2 should have exactly 1 message, got %d", len(customer2.ReceivedMsgs))
+	}
+
+	if len(logger.LogData) != 1 {
+		t.Errorf("logger should")
 	}
 }


### PR DESCRIPTION
SystemLoggerを追加した
Itemの構造体やNotifyAllの中身は修正する必要がない
単一責任だけをこなすことが可能